### PR TITLE
fixed failure count always being 0 on Worker detail page

### DIFF
--- a/lib/Resque/Failure/Redis.pm
+++ b/lib/Resque/Failure/Redis.pm
@@ -22,6 +22,7 @@ sub save {
         queue     => $self->queue
     });
     $self->resque->redis->rpush( $self->resque->key( 'failed' ), $data );
+    $self->resque->redis->incr( $self->resque->key("stat:failed:" . $self->worker->id));
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
updated failure save method to increment stat:failed:(worker_id) key
so the detail page for a worker will show the correct number of 
failures
