### PR TITLE
around can't call on constructor. then, call error method by sub BUILD

### DIFF
--- a/t/04-failure.t
+++ b/t/04-failure.t
@@ -35,6 +35,9 @@ $r->flush_namespace;
     is( my @fails = $r->failures->all(0,-1), 2, 'Get all() two failures' );
     ok( $fails[0]->{retried_at}, 'First one has been retried' );
     ok( ! $fails[1]->{retried_at}, 'Seccond one has not been retried' );
+    ok( $fails[0]->{backtrace}, 'parse error and set backtrace' ) or diag explain $fails[0];
+    ok( ref $fails[0]->{backtrace} eq 'ARRAY', 'backtrace is ArrayRef. for resque-web' );
+    ok( $fails[0]->{error} !~ /\n/, '$fail->{error} have no "\n"') or diag $fails[0]->{error};
 }
 
 sub push_job {

--- a/t/lib/Test/FailWorker.pm
+++ b/t/lib/Test/FailWorker.pm
@@ -2,10 +2,11 @@ package # hide from cpan
     Test::FailWorker;
 
 use strict;
+use Carp;
 
 sub perform {
     my $job = shift;
-    die "Bye bye cruel world!";
+    Carp::confess "Bye bye cruel world!";
 }
 
 1;


### PR DESCRIPTION
Hi. Thanks to make resque clone.

I found 2 issue to use with ruby resque-web.
1. backtrace is always undef by default.
   "around 'error'" is not called on Resque::Failure->new.
   So, argument error is not parsed and always backtrace is undef until set error by method call.
2. resque-web expect 'backtrace' is array.

I want to use resque-web on develpment. but resque v1.23.0 expect backtrace is array.
Then, I change backtrace isa 'Str' -> 'ArrayRef[Str]'.
