### PR TITLE
applied patch for forked process status

### DIFF
--- a/t/lib/Test/LongRunningWorker.pm
+++ b/t/lib/Test/LongRunningWorker.pm
@@ -1,0 +1,13 @@
+package # hide from cpan
+    Test::LongRunningWorker;
+
+use strict;
+use Carp;
+
+sub perform {
+    my $job = shift;
+    
+    sleep 10;
+}
+
+1;


### PR DESCRIPTION
Hi Diego,

as promised earlier today, here is the pull request for the changes I did in order to monitor the child process status and make a non-zero exit status fail. Would be great to see this change in your repository.

In the meantime, I have switched my perl to 5.18.0 and observed 4 Tests in 02-queue.t failing approximately every 3rd run, while 5.16.3 still succeeds. Nothing serious, I hope.

Best,

Wolfgang
