### PR TITLE
More extensible payload

### DIFF
--- a/lib/Resque/Job.pm
+++ b/lib/Resque/Job.pm
@@ -71,15 +71,11 @@ has payload => (
     isa  => 'HashRef',
     coerce => 1,
     lazy => 1,
-    default => sub {{
-        class => $_[0]->class,
-        args  => $_[0]->args
-    }},
+    builder => '_build_payload',
     trigger => sub {
         my ( $self, $hr ) = @_;
-        $self->class( $hr->{class} );
-        $self->args( $hr->{args} ) if $hr->{args};
-    }
+        $self->_trigger_payload($hr);
+    },
 );
 
 =method encode
@@ -187,6 +183,21 @@ sub fail {
         exception => $exception,
         error     => $error
     );
+}
+
+sub _build_payload {
+    my ($self,) = @_;
+
+    return +{
+        class => $self->class,
+        args  => $self->args,
+    };
+}
+
+sub _trigger_payload {
+    my ( $self, $hr ) = @_;
+    $self->class( $hr->{class} );
+    $self->args( $hr->{args} ) if $hr->{args};
 }
 
 __PACKAGE__->meta->make_immutable();

--- a/t/07-job.t
+++ b/t/07-job.t
@@ -1,0 +1,50 @@
+use Test::More;
+use Resque;
+use lib 't/lib';
+use Test::SpawnRedisServer;
+
+my ($c, $server) = redis();
+END { $c->() if $c }
+
+ok ( my $r = Resque->new( redis => $server, namespace => 'test_resque' ), "Building object for test server $server" );
+ok ( $r->redis, 'Has redis object' );
+ok ( $r->redis->ping, 'Redis object is alive' );
+
+$r->flush_namespace;
+{
+    my $worker = 'Test::Worker';
+    my $args   = [+{ test_arg1 => 'hoge' }, +{ test_arg2 => 'huga' }];
+
+    my $job = Resque::Job->new(
+        +{
+            resque  => $resque,
+            payload => +{
+                class => $worker,
+                args  => $args,
+            }
+        }
+    );
+
+    isa_ok( $job, 'Resque::Job' );
+    is $job->class, $worker;
+    is_deeply $job->args, $args;
+    is_deeply $job->payload, +{
+        class => $worker,
+        args  => $args,
+    }, 'Build payload';
+
+    $job->payload->{args} = ['please run trigger'];
+    is_deeply $job->payload, +{
+        class => $worker,
+        args  => ['please run trigger'],
+    }, 'Re build payload';
+
+    $job->payload->{class} = 'Hoge::Worker';
+    is_deeply $job->payload, +{
+        class => 'Hoge::Worker',
+        args  => ['please run trigger'],
+    }, 'Re build payload';
+
+}
+
+done_testing();


### PR DESCRIPTION
Hi.
I am sorry for my poor English.

In order to use this module, I created several plugins, but as problems occurred with payload handling, I created a corresponding pull request.

I wanted to extend payload so that we can have key indicating retry count and job execution time in order to delay retry and job execution. I thought it was more intuitive as an interface than storing special values in "args".

Although it was easy to realize it, a bit of a problem occurred due to the use of Resque::Job# payload default and trigger.

It is based on the assumption that payload is initialized with default, updating when there is a change to payload by trigger, but only key is "class" and "args".

If you use only one plugin, you just overwrite the payload attribute itself, but if you want to extend payload with multiple plugins, the mutual attribute definitions will interfere.
I will have multiple plugins I'd like to extend payload with.

In order to avoid this, I want to overwrite the default trigger using "around" of Moose, but it is difficult because I use anonymous subroutines for default and trigger.

In order to solve it, we defined a method for builder and trigger separately and took it in the form of calling it. In this case it is easy to overwrite with Moose's function from the plugin side. Even if you extend with multiple plugins, you can use Moose's "around" without problems.

Please consider application of change.

For reference, already I have released a plugin to extend one payload.
It is a plugin that delays job execution. Currently payload is overwritten directly.

https://github.com/meru-akimbo/resque-delay-perl
https://metacpan.org/pod/Resque::Plugin::Delay

Another plugin to retry is also in the process of developing.
If this pull request is also adopted, I think that plug-in can be released in the near future.
