### PR TITLE
fix --redis=server:port option on resque-worker

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 {{$NEXT}}
 
     - Fixed cant_fork option on resque-worker (#GH21)
+    - Fixed --redis server:port option on resque-worker
 
 0.26      2016-08-19 20:27:43+02:00 Europe/Madrid
 

--- a/bin/resque-worker
+++ b/bin/resque-worker
@@ -17,7 +17,7 @@ $w->work;
 sub getopt {
     my ($opt, $usage) = describe_options(
         "resque-worker \%o",
-        [ 'redis|r=s@',   "Redis server (default: 127.0.0.1:6379)", { default => '127.0.0.1:6379' } ],
+        [ 'redis|r=s',   "Redis server (default: 127.0.0.1:6379)", { default => '127.0.0.1:6379' } ],
         [ 'queue|q=s@',   "Queue name/s (required)", { required => 1 } ],
         [],
         [ 'interval|i=f', "Polling interval in floating seconds for this resque worker (Default 5 seconds)", { default => 5 } ],

--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,8 @@ Redis = 0
 [Prereqs / TestRequires]
 Test::More = 0.96
 Test::Exception = 0.29
+Test::Pod::Coverage = 0
+Test::Pod = 0
 
 [Git::NextVersion]
 first_version = 0.01


### PR DESCRIPTION
When I used the --redis=server:port option on resque-worker like so:

    % resque-worker --redis servername:6379 --queue A

I get this error: 

    Attribute (redis) does not pass the type constraint because: Validation failed for 
    'Sugar::Redis' with value [ "servername:6379" ] at constructor Resque::new 
    (defined at ...site_perl/5.24.0/Resque.pm line 165) line 58

This patch fixes the issue and allows resque-worker to connect to remote redis servers.
