### PR TITLE
add more examples to pod

### DIFF
--- a/lib/Resque.pm
+++ b/lib/Resque.pm
@@ -253,7 +253,7 @@ sub remove_queue {
 
 Given a queue name, creates an empty queue.
     
-    $r-create_queue( 'my_queue' );
+    $r->create_queue( 'my_queue' );
 
 =cut
 sub create_queue {

--- a/lib/Resque/Failures.pm
+++ b/lib/Resque/Failures.pm
@@ -40,6 +40,10 @@ has failure_class => (
 
 create() a failure on the failure_class() and save() it.
 
+$failures->throw( %job_description_hash );
+
+See L<Resque> code for a usage example.
+
 =cut
 sub throw {
     my $self = shift;
@@ -51,6 +55,8 @@ sub throw {
 
 Create a new failure on the failure_class() backend.
 
+$failures->create( ... );
+
 =cut
 sub create {
     my $self = shift;
@@ -59,7 +65,9 @@ sub create {
 
 =method count
 
-How many failures was in all the resque system.
+How many failures are in the resque system.
+
+my $count = $failures->count();
 
 =cut
 sub count {
@@ -69,8 +77,10 @@ sub count {
 
 =method all
 
-Return a range of failures in the same way Resque::peek() does for
-jobs.
+Return a range of failures (or an arrayref in scalar context)
+in the same way Resque::peek() does for jobs.
+
+my @failures = $failures->all('my_queue', $opt_start, $opt_count);
 
 =cut
 sub all {
@@ -86,6 +96,8 @@ sub all {
 
 Remove all failures.
 
+$failures->clear();
+
 =cut
 sub clear {
     my $self = shift;
@@ -97,6 +109,8 @@ sub clear {
 Requeue by index number.
 
 Failure will be updated to note retried date.
+
+$failures->requeue( $index );
 
 =cut
 sub requeue {
@@ -123,6 +137,8 @@ Please note that, when you remove some index, all
 sucesive ones will move left, so index will decrese
 one. If you want to remove several ones start removing
 from the rightmost one.
+
+$failures->remove( $index );
 
 =cut
 sub remove {

--- a/lib/Resque/Job.pm
+++ b/lib/Resque/Job.pm
@@ -186,10 +186,10 @@ sub dequeue {
 
 =method fail
 
-Store a failure (or arrayref of failures) on this job.
+Store a failure (or exception and failure) on this job.
 
     $job->fail( "error message'); # or
-    $job->fail( ['msg1', 'msg2'] );
+    $job->fail( ['exception', 'error message'] );
 
 =cut
 sub fail {

--- a/lib/Resque/Plugin.pm
+++ b/lib/Resque/Plugin.pm
@@ -10,7 +10,9 @@ Moose::Exporter->setup_import_methods(
 );
 
 =method add_to
+
 Role applier for Resque, Resque::Worker and Resque::Job.
+
 =cut
 sub add_to {
     my ( $meta, $to, @options ) = @_;

--- a/lib/Resque/Stat.pm
+++ b/lib/Resque/Stat.pm
@@ -15,6 +15,8 @@ has resque => (
 
 Returns the int value of a stat, given a string stat name.
 
+my $value = $resque_stat->get( 'stat_name' );
+
 =cut
 sub get {
     my ($self, $stat) = @_;
@@ -27,6 +29,8 @@ For a string stat name, increments the stat by one.
 
 Can optionally accept a second int parameter. The stat is then
 incremented by that amount.
+
+my $value = $resque_stat->incr( 'stat_name', $optional_inc_by );
 
 =cut
 sub incr {
@@ -42,6 +46,8 @@ For a string stat name, decrements the stat by one.
 Can optionally accept a second int parameter. The stat is then
 decremented by that amount.
 
+my $value = $resque_stat->decr( 'stat_name', $optional_dec_by );
+
 =cut
 sub decr {
     my ( $self, $stat, $by ) = @_;
@@ -52,6 +58,8 @@ sub decr {
 =method clear
 
 Removes a stat from Redis, effectively setting it to 0.
+
+$resque_stat->clear( 'stat_name' );
 
 =cut
 sub clear {

--- a/lib/Resque/WorkerClass.pm
+++ b/lib/Resque/WorkerClass.pm
@@ -65,6 +65,8 @@ This will be called by L<Resque::Worker> to perform() your job. This is the glue
 implementation that will initialize an instance of your class and call your run()
 method on it.
 
+$workerclass->perform( $resque_job );
+
 =cut
 sub perform {
     my ($meta, $job) = @_;


### PR DESCRIPTION
Some doc changes. 

Perhaps you can suggest usage examples for 

     $failures->create( ... ); 
     and
      $failures->throw( %job_description_hash ); 

also am I documenting

    $job->fail( ['exception', 'error message'] );

correctly?