### PR TITLE
Allow graceful shutdown in "cant_fork" mode

### DIFF
--- a/lib/Resque/Worker.pm
+++ b/lib/Resque/Worker.pm
@@ -115,7 +115,7 @@ has interval => ( is => 'rw', default => sub{5} );
 
 Stop processing jobs after the current one has completed (if we're
 currently running one).
- 
+
 $worker->pause();
 
 =cut
@@ -209,7 +209,9 @@ sub work_tick {
     else {
         undef $SIG{TERM};
         undef $SIG{INT};
-        undef $SIG{QUIT};
+
+        # Allow graceful shutdown in "cant fork mode"
+        undef $SIG{QUIT} unless $self->cant_fork;
 
         $self->procline( sprintf( "Processing %s since %s", $job->queue, $timestamp ) );
         $self->perform($job);


### PR DESCRIPTION
Hello.

When "cant_fork" is enabled, I noticed that gracefull shutdown can not be performed and I was in trouble. Even if "cant_fork" is enabled, processing by QUIT signal is restored to default.

I propose to keep the processing when receiving the QUIT signal as "shutdown_please" so that graful shutdown can be performed.
