### PR TITLE
Fix -M to resque-worker

### DIFF
--- a/bin/resque-worker
+++ b/bin/resque-worker
@@ -5,9 +5,10 @@
 use strict;
 use Resque;
 use Getopt::Long::Descriptive;
+use Class::Load;
 
 my $opt = getopt();
-$_->require for @{$opt->module||[]};
+load_class($_) for @{$opt->module||[]};
 
 my $w = Resque->new( redis => $opt->redis )->worker;
 $w->$_($opt->$_) for qw/ interval verbose cant_fork/;


### PR DESCRIPTION
`$_->require` doesn't work:

    Can't locate object method "require" via package "My::Init" (perhaps you forgot to load "My::Init"?) at /opt/perl5/bin/resque-worker line 10.

Class::Load was already in use elsewhere in the code so it was simple enough to use it again.