### PR TITLE
More options for Redis connections

### DIFF
--- a/lib/Resque.pm
+++ b/lib/Resque.pm
@@ -79,7 +79,7 @@ A lot more about Resque can be read on the original blog post: L<http://github.c
 
 =attr redis
 
-Redis instance for this Resque instance. Accepts a string, L<Redis>, L<Redis::Fast> or any other object that behaves like those.
+Redis instance for this Resque instance. Accepts a string, hash reference, L<Redis>, L<Redis::Fast> or any other object that behaves like those.
 
 When a string is passed in, it will be used as the server argument of a new client object. When L<Redis::Fast> is available this
 will be used, when not the pure perl L<Redis> client will be used instead.
@@ -94,6 +94,15 @@ coerce 'Sugar::Redis' => from 'Str' => via {
         every     => 250,
         encoding  => undef
     )
+};
+
+coerce 'Sugar::Redis' => from 'HashRef' => via {
+    _redis_class->new((
+        reconnect => 60,
+        every     => 250,
+        encoding  => undef,
+        %$_,
+    ));
 };
 
 has redis => (

--- a/t/08-redis_connection.t
+++ b/t/08-redis_connection.t
@@ -1,0 +1,23 @@
+use Test::More;
+use Resque;
+use lib 't/lib';
+use Test::SpawnRedisServer;
+
+my ($c, $server) = redis();
+END { $c->() if $c }
+
+{
+    ok ( my $r = Resque->new( redis => { server => $server }, namespace => 'test_resque' ), "Building object for test server $server" );
+    ok ( $r->redis, 'Has redis object' );
+    ok ( $r->redis->ping, 'Redis object is alive' );
+    is ( ref $r->redis eq 'Redis::Fast' ? $r->redis->__get_reconnect : $r->redis->{reconnect}, 60, 'Default parameters are loaded' );
+}
+
+{
+    ok ( my $r = Resque->new( redis => { server => $server, reconnect => 120 }, namespace => 'test_resque' ), "Building object for test server $server" );
+    ok ( $r->redis, 'Has redis object' );
+    ok ( $r->redis->ping, 'Redis object is alive' );
+    is ( ref $r->redis eq 'Redis::Fast' ? $r->redis->__get_reconnect : $r->redis->{reconnect}, 120, 'Default values have been overwritten' );
+}
+
+done_testing();


### PR DESCRIPTION
Currently you can only indicate host and port to establish against which Redis the connection should be made. Although this is sufficient in most cases, in some occasions it may be insufficient since other parameters cannot be passed to it.

With this Pull Requets I intend to solve this limitation and offer the possibility of customizing the default values that the library incorporates when starting a new connection. 

I have created a new file to test the changes, since I have not seen any other clear option. If it is considered that these tests can be embedded in any of the existing files I will be happy to make the necessary changes. 