### PR TITLE
Avoid inheriting from Exporter in test class

### DIFF
--- a/t/lib/Test/SpawnRedisServer.pm
+++ b/t/lib/Test/SpawnRedisServer.pm
@@ -8,7 +8,7 @@ use warnings;
 use File::Temp;
 use IPC::Cmd qw(can_run);
 use POSIX ":sys_wait_h";
-use base qw( Exporter );
+use Exporter qw( import );
 
 our @EXPORT = qw( redis );
 


### PR DESCRIPTION
This follows more closely the modern recommended use of Exporter, and also means we no longer use `base`, which is discouraged in favour of `parent`.